### PR TITLE
correct spelling of OS X

### DIFF
--- a/layers/osx/README.html
+++ b/layers/osx/README.html
@@ -6,7 +6,7 @@
 <!-- 2016-03-12 Sat 14:09 -->
 <meta  http-equiv="Content-Type" content="text/html;charset=utf-8" />
 <meta  name="viewport" content="width=device-width, initial-scale=1" />
-<title>OSX layer</title>
+<title>OS X layer</title>
 <meta  name="generator" content="Org-mode" />
 <meta  name="author" content="Sylvain Benner" />
 <style type="text/css">
@@ -162,7 +162,7 @@ for the JavaScript code in this tag.
 <body>
 <div id="content">
 <div id="toggle-sidebar"><a href="#table-of-contents"><h2>Table of Contents</h2></a></div>
-<h1 class="title">OSX layer</h1>
+<h1 class="title">OS X layer</h1>
 <div id="table-of-contents">
 <h2>Table of Contents<a href="#">Close</a></h2>
 <div id="text-table-of-contents">
@@ -194,8 +194,8 @@ for the JavaScript code in this tag.
 <h2 id="orgheadline1"><span class="section-number-2">1</span> Description</h2>
 <div class="outline-text-2" id="text-1">
 <p>
-Spacemacs is not just emacs+vim. It can have OSX keybindings too!
-This layer globally defines common OSX keybindings. <code>⌘</code> is set to
+Spacemacs is not just emacs+vim. It can have OS X keybindings too!
+This layer globally defines common OS X keybindings. <code>⌘</code> is set to
 <code>super</code> and <code>⌥</code> is set to <code>meta</code>. Aside from that, there's nothing
 much, really.
 </p>
@@ -210,8 +210,8 @@ While in <code>dired</code> this layer will try to use <code>gls</code> instead 
 <h2 id="orgheadline2"><span class="section-number-2">2</span> Philosophy</h2>
 <div class="outline-text-2" id="text-2">
 <p>
-While this layer enables common OSX bindings, it does not implement
-OSX navigation keybindings. Spacemacs is meant to be used with evil,
+While this layer enables common OS X bindings, it does not implement
+OS X navigation keybindings. Spacemacs is meant to be used with evil,
 and we encourage you to do so :)
 </p>
 </div>
@@ -371,7 +371,7 @@ To get <code>gls</code> install coreutils homebrew:
 <ul class="org-ul">
 <li>Allow user to choose from either <code>hyper</code> or <code>super</code> as <code>⌘</code>. This is an option
 that is supported cross-platform.</li>
-<li>Configurable option to keep the OSX and spacemacs clipboards separate</li>
+<li>Configurable option to keep the OS X and spacemacs clipboards separate</li>
 </ul>
 </div>
 </div>


### PR DESCRIPTION
The correct spelling for "OS X" includes a space between "OS" and "X".  This makes sense, because "OS" is (of course) an initialism for operating system, and "X" is a Roman numeral (and is pronounced as "ten", by the way).  It would be odd if Apple had decided to jam them together as though X were the initial of another word.  For those of us using Macs going back to the day when dinosaurs walked the earth, it also continues logically from Mac OS 9 (http://toastytech.com/guis/macos9about.png).
