### PR TITLE
Correct capitalization of Github to GitHub.

### DIFF
--- a/doc/DOCUMENTATION.html
+++ b/doc/DOCUMENTATION.html
@@ -4150,7 +4150,7 @@ page instead.
 <p>
 Spacemacs uses <a href="https://github.com/Bruce-Connor/paradox">Paradox</a> instead of <code>package-list-packages</code> to list available
 ELPA packages. Paradox enhances the package list buffer with better feedbacks,
-new filters and Github information like the number of stars. Optionally you can
+new filters and GitHub information like the number of stars. Optionally you can
 also star packages directly in the buffer.
 </p>
 
@@ -4268,7 +4268,7 @@ Spacemacs.
 
 <tr>
 <td class="org-left"><code>S *</code></td>
-<td class="org-left">sort by Github stars</td>
+<td class="org-left">sort by GitHub stars</td>
 </tr>
 
 <tr>
@@ -9678,7 +9678,7 @@ server is to use the following bindings:
 If any errors happen during the loading the mode-line will turn red and the
 errors should appear inline in the startup buffer. Spacemacs should still be
 usable; if it is not then restart Emacs with <code>emacs --debug-init</code> and open a
-<a href="https://github.com/syl20bnr/spacemacs/issues">Github issue</a> with the backtrace.
+<a href="https://github.com/syl20bnr/spacemacs/issues">GitHub issue</a> with the backtrace.
 </p>
 </div>
 </div>

--- a/doc/VIMUSERS.html
+++ b/doc/VIMUSERS.html
@@ -613,7 +613,7 @@ functions are the first thing you should refer to.
 <div class="outline-text-3" id="text-exploring">
 <p>
 There are a few ways to explore the functionality of Spacemacs. One is to read
-the <a href="https://github.com/syl20bnr/spacemacs">source code</a> on Github. You can begin to feel your way around Emacs Lisp and
+the <a href="https://github.com/syl20bnr/spacemacs">source code</a> on GitHub. You can begin to feel your way around Emacs Lisp and
 how Spacemacs works this way. You can also use the following keybindings to
 explore:
 </p>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
 
             <li class="nav-item nav-item-toggable">
-              <a class="nav-link" href="https://github.com/syl20bnr/spacemacs" target="_blank"><span class="fa fa-github"></span> Github</a>
+              <a class="nav-link" href="https://github.com/syl20bnr/spacemacs" target="_blank"><span class="fa fa-github"></span> GitHub</a>
             </li>
 
             <li class="navbar-divider hidden-sm-down"></li>

--- a/layers/+emacs/org/README.html
+++ b/layers/+emacs/org/README.html
@@ -175,7 +175,7 @@ for the JavaScript code in this tag.
 <li><a href="#install">2. Install</a>
 <ul>
 <li><a href="#layer">2.1. Layer</a></li>
-<li><a href="#github-support">2.2. Github support</a></li>
+<li><a href="#github-support">2.2. GitHub support</a></li>
 <li><a href="#gnuplot-support">2.3. Gnuplot support</a></li>
 <li><a href="#revealjs-support">2.4. Reveal.js support</a></li>
 <li><a href="#different-bullets">2.5. Different bullets</a></li>
@@ -297,10 +297,10 @@ file.
 </div>
 
 <div id="outline-container-orgheadline6" class="outline-3">
-<h3 id="github-support"><a id="orgheadline6"></a><span class="section-number-3">2.2</span> Github support</h3>
+<h3 id="github-support"><a id="orgheadline6"></a><span class="section-number-3">2.2</span> GitHub support</h3>
 <div class="outline-text-3" id="text-github-support">
 <p>
-To install Github related extensions like <a href="https://github.com/larstvei/ox-gfm">ox-gfm</a> to export to Github
+To install GitHub related extensions like <a href="https://github.com/larstvei/ox-gfm">ox-gfm</a> to export to GitHub
 flavored markdown set the variable <code>org-enable-github-support</code> to <code>t</code>.
 </p>
 

--- a/layers/+lang/markdown/README.html
+++ b/layers/+lang/markdown/README.html
@@ -218,7 +218,7 @@ This layer adds markdown support to Spacemacs.
 <div class="outline-text-3" id="text-features">
 <ul class="org-ul">
 <li>markdown files support via <a href="http://jblevins.org/git/markdown-mode.git/">markdown-mode</a></li>
-<li>Fast Github-flavored live preview via <a href="https://github.com/blak3mill3r/vmd-mode">vmd-mode</a></li>
+<li>Fast GitHub-flavored live preview via <a href="https://github.com/blak3mill3r/vmd-mode">vmd-mode</a></li>
 <li>TOC generation via <a href="https://github.com/ardumont/markdown-toc">markdown-toc</a></li>
 <li>Completion of Emojis using <a href="https://github.com/dunn/company-emoji">company-emoji</a> (still needs a way of showing, either
 using the <code>emoji</code> layer or having a proper font) :clap:</li>
@@ -262,7 +262,7 @@ buffer.
 </p>
 
 <p>
-To use <code>vmd</code> (Github-flavored live preview) instead set the value of the
+To use <code>vmd</code> (GitHub-flavored live preview) instead set the value of the
 variable <code>markdown-live-preview-engine</code> to <code>vmd</code>:
 </p>
 
@@ -432,7 +432,7 @@ To generate a table of contents type on top of the buffer:
 
 <tr>
 <td class="org-left"><code>SPC m x C</code></td>
-<td class="org-left">make region code or insert code (Github Flavored Markdown format)</td>
+<td class="org-left">make region code or insert code (GitHub Flavored Markdown format)</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
This is pedantic, but the official capitalization is with a capital H, as in GitHub. This fix was made programmatically.

I'm sorry to open this 😛 it just really irks me to see Github instead of GitHub in official docs.